### PR TITLE
changes to solve Wikipedia Demo runtime error 

### DIFF
--- a/lib/src/wiki/wikipedia_service.dart
+++ b/lib/src/wiki/wikipedia_service.dart
@@ -5,7 +5,7 @@ import 'package:jsonpadding/jsonpadding.dart';
 
 @Injectable()
 class WikipediaService {
-  Future<List<String>> search(String term) async {
+  Future<List> search(String term) async {
     Uri uri = new Uri(
         scheme: 'http',
         host: 'en.wikipedia.org',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   angular: ^5.0.0-alpha
   http: ^0.11.0
-  jsonpadding: ^0.1.0
+  jsonpadding: ^1.0.1
   stream_transform: ^0.0.5
 
 dev_dependencies:


### PR DESCRIPTION
updated jsonpadding version and changed the return type of search function to resolve runtime exception error. 

Thank you! :) 

related issues: dart-lang/site-webdev#1575